### PR TITLE
Catch JSON.parse syntax errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,11 @@ export function send(method, uri, opts={}) {
 			r.on('end', () => {
 				let type = r.headers['content-type'];
 				if (type && out && type.includes('application/json')) {
-					out = JSON.parse(out, opts.reviver);
+					try {
+						out = JSON.parse(out, opts.reviver);
+					} catch (err) {
+						return rej(err);
+					}
 				}
 				r.data = out;
 				if (r.statusCode >= 400) {


### PR DESCRIPTION
A thrown `SyntaxError` from `JSON.parse` is not inside a catch block.

Example:
`SyntaxError: Unexpected end of JSON input`
Will exit current node process.