### PR TITLE
Abort request on timeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,11 @@ export function send(method, uri, opts={}) {
 			});
 		});
 
+		req.on('timeout', () => {
+			req.abort();
+			rej(new Error('Request timed out'));
+		});
+
 		req.on('error', rej);
 
 		if (opts.body) {

--- a/test/index.js
+++ b/test/index.js
@@ -210,3 +210,13 @@ test('Error: Invalid JSON', async t => {
 		ctx.close();
 	});
 });
+
+test('Error: Request timed out', async t => {
+	t.plan(7);
+	let ctx = await server();
+	await httpie.get(`https://reqres.in/api/any`, { timeout: 1 }).catch(err => {
+		t.true(err instanceof Error, '~> caught Request timed out');
+		t.true(err.message.includes('Request timed out'), '~> had "Request timed out" message');
+		ctx.close();
+	});
+});

--- a/test/index.js
+++ b/test/index.js
@@ -213,10 +213,8 @@ test('Error: Invalid JSON', async t => {
 
 test('Error: Request timed out', async t => {
 	t.plan(7);
-	let ctx = await server();
 	await httpie.get(`https://reqres.in/api/any`, { timeout: 1 }).catch(err => {
 		t.true(err instanceof Error, '~> caught Request timed out');
 		t.true(err.message.includes('Request timed out'), '~> had "Request timed out" message');
-		ctx.close();
 	});
 });

--- a/test/index.js
+++ b/test/index.js
@@ -213,7 +213,7 @@ test('Error: Invalid JSON', async t => {
 
 test('Error: Request timed out', async t => {
 	t.plan(7);
-	await httpie.get(`https://reqres.in/api/any`, { timeout: 1 }).catch(err => {
+	await httpie.get('https://reqres.in/api/any', { timeout: 1 }).catch(err => {
 		t.true(err instanceof Error, '~> caught Request timed out');
 		t.true(err.message.includes('Request timed out'), '~> had "Request timed out" message');
 	});


### PR DESCRIPTION
Currently, if `timeout` is defined in [`request options`](https://nodejs.org/api/http.html#http_http_request_url_options_callback), it's ignored and the request does not abort.

Shamefully adopted from:
[feross/simple-get/index.js#L65](https://github.com/feross/simple-get/blob/d4a4b65d6a7f7499fd588409bfcdf66c3984d43a/index.js#L65)
@feross 🤓