### PR TITLE
use "exports" for broader support

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -5,7 +5,7 @@ function apply(src, tar) {
 	tar.data = src.response;
 }
 
-export function send(method, uri, opts) {
+exports.send = function (method, uri, opts) {
 	return new Promise(function (res, rej) {
 		opts = opts || {};
 		var k, str, tmp, arr;
@@ -58,8 +58,8 @@ export function send(method, uri, opts) {
 	});
 }
 
-export var get = send.bind(send, 'GET');
-export var post = send.bind(send, 'POST');
-export var patch = send.bind(send, 'PATCH');
-export var del = send.bind(send, 'DELETE');
-export var put = send.bind(send, 'PUT');
+exports.get = exports.send.bind(exports.send, 'GET');
+exports.post = exports.send.bind(exports.send, 'POST');
+exports.patch = exports.send.bind(exports.send, 'PATCH');
+exports.del = exports.send.bind(exports.send, 'DELETE');
+exports.put = exports.send.bind(exports.send, 'PUT');


### PR DESCRIPTION
I'm using `httpie@next` for a while on `colyseus.js`, and I've seen some people having issues in some environments due to the usage of the `export` keyword. My proposal here is to use the old-school `exports.xxx = ` to better integrate with existing tools out there.

- [Gatsby issue](https://github.com/colyseus/colyseus.js/issues/64)
- [NativeScript issue](https://discuss.colyseus.io/topic/320/error-nativescript) 
![nativescript](https://user-images.githubusercontent.com/130494/82760714-d83cb300-9dcb-11ea-8bd7-343ef2f9c83c.png)
