### PR TITLE
chore(package.json): add "./package.json" to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "./xhr": {
       "import": "./xhr/index.mjs",
       "require": "./xhr/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "author": {
     "name": "Luke Edwards",


### PR DESCRIPTION
The newest version of node are met with this error: 
![ ](https://user-images.githubusercontent.com/454023/91088619-f5c22880-e617-11ea-8fdc-69b3049414ec.png)

This fixes it by adding "./package.json": "./package.json" to the listed exports.

:neckbeard: